### PR TITLE
Remove 5min connection timeout when restoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ docker run \
 
 ### Restore
 
-Note that the restore function has no timeout. This may lead to the restore hanging indefinitely if something goes wrong, but doesn't cause the app to crash (unlikely, but possible).
+Note that the restore function no longer has a timeout. This may lead to the restore hanging indefinitely if something goes wrong, but doesn't cause the app to crash (unlikely, but possible).
 
 ```
  docker run \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ docker run \
 
 
 ### Restore
+
+Note that the restore function has no timeout. This may lead to the restore hanging indefinitely if something goes wrong, but doesn't cause the app to crash (unlikely, but possible).
+
 ```
  docker run \
            -e MONGODB=<MONGODB_ADDRESSES> \

--- a/app.go
+++ b/app.go
@@ -228,7 +228,7 @@ func dumpCollectionTo(connStr string, database, collection string, writer io.Wri
 }
 
 func restoreCollectionFrom(connStr, database, collection string, reader io.Reader) error {
-	session, err := mgo.DialWithTimeout(connStr, 5*time.Minute)
+	session, err := mgo.Dial(connStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The MongoDB database connection for the restore function had a 5 minute timeout, causing restores to fail with large collections that took more than 5mins to restore.

This PR removes the timeout. 