### PR TITLE
Remove restore connection timeout

### DIFF
--- a/app.go
+++ b/app.go
@@ -228,7 +228,7 @@ func dumpCollectionTo(connStr string, database, collection string, writer io.Wri
 }
 
 func restoreCollectionFrom(connStr, database, collection string, reader io.Reader) error {
-	session, err := mgo.Dial(connStr)
+	session, err := mgo.DialWithTimeout(connStr, 5*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/app.go
+++ b/app.go
@@ -228,7 +228,7 @@ func dumpCollectionTo(connStr string, database, collection string, writer io.Wri
 }
 
 func restoreCollectionFrom(connStr, database, collection string, reader io.Reader) error {
-	session, err := mgo.DialWithTimeout(connStr, 5*time.Minute)
+	session, err := mgo.DialWithTimeout(connStr, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Turns out that `Dial` has a default timeout of 1 minute - this didn't come up when I tested previously, as I'd already emptied the collection.

This change uses `DialWithTimeout` with a timeout of 0, which should be infinite.