### PR TITLE
Add rate limiting to MongoDB restores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.4
 ADD . /source/
-
 RUN apk add --update bash \
-  && apk --update add git go ca-certificates
-
-RUN export GOPATH=/gopath \
+  && apk --update add git go ca-certificates \
+  && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/mongodb-hot-backup/" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv /source/* $GOPATH/src/${REPO_PATH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.4
+FROM alpine:3.5
 ADD . /source/
 RUN apk add --update bash \
-  && apk --update add git go ca-certificates \
+  && apk --update add git go libc-dev ca-certificates \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/mongodb-hot-backup/" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update bash \
   && go get ./... \
   && go install ${REPO_PATH} \
   && mv ${GOPATH}/bin/mongodb-hot-backup / \
-  && apk del go git \
+  && apk del go git libc-dev \
   && rm -rf $GOPATH /var/cache/apk/*
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.4
 ADD . /source/
 RUN apk add --update bash \
-  && apk --update add git go ca-certificates \
-  && export GOPATH=/gopath \
+  && apk --update add git go ca-certificates
+
+RUN export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/mongodb-hot-backup/" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
   && mv /source/* $GOPATH/src/${REPO_PATH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM alpine:3.4
 ADD . /source/
+
 RUN apk add --update bash \
   && apk --update add git go ca-certificates
 

--- a/app.go
+++ b/app.go
@@ -272,7 +272,7 @@ func restoreCollectionFrom(connStr, database, collection string, reader io.Reade
 			}
 
 			var duration = time.Since(batchStart)
-			log.Infof("Written bulk restore batch. Took %v", duration)
+			log.Infof("Written bulk restore batch for %s/%s. Took %v", database, collection, duration)
 
 			// rate limit between writes to prevent overloading MongoDB
 			limiter.Wait(context.Background())

--- a/app.go
+++ b/app.go
@@ -249,8 +249,8 @@ func restoreCollectionFrom(connStr, database, collection string, reader io.Reade
 	var batchBytes int
 	batchStart := time.Now()
 
-	// set rate limit to 50ms
-	limiter := rate.NewLimiter(rate.Every(50 * time.Millisecond), 1)
+	// set rate limit to 250ms
+	limiter := rate.NewLimiter(rate.Every(250 * time.Millisecond), 1)
 
 	for {
 		


### PR DESCRIPTION
- add logging after every batch write
- upgrade Alpine 3.4 > 3.5
- upgrade go 1.6 > 1.7
- add rate limiting to prevent OOM issues with large collection restores  