### PR TITLE
increased memory limits

### DIFF
--- a/helm/mongo-hot-backup/values.yaml
+++ b/helm/mongo-hot-backup/values.yaml
@@ -16,4 +16,4 @@ resources:
   requests:
     memory: 64Mi
   limits:
-    memory: 512Mi
+    memory: 2560Mi

--- a/httpService.go
+++ b/httpService.go
@@ -26,7 +26,7 @@ func newScheduleHTTPService(scheduler scheduler, healthService *healthService) *
 }
 
 func (h *scheduleHTTPService) ScheduleAndServe(colls []dbColl, cronExpr string, runAtStart bool) {
-	h.scheduler.SheduleBackups(colls, cronExpr, runAtStart)
+	go h.scheduler.SheduleBackups(colls, cronExpr, runAtStart)
 
 	hc := health.TimedHealthCheck{
 		HealthCheck: health.HealthCheck{


### PR DESCRIPTION
noticed in CoCo it grows up to 1.742GB memory usage, so increased the limits in k8s configs. Will profile why it is growing, later.