### PR TITLE
Do not backup "v1-metadata" collection anymore

### DIFF
--- a/helm/mongo-hot-backup/app-configs/mongo-hot-backup_eks_publish.yaml
+++ b/helm/mongo-hot-backup/app-configs/mongo-hot-backup_eks_publish.yaml
@@ -5,4 +5,4 @@ service:
 replicaCount: 1
 
 env:
-  MONGODB_COLLECTIONS: native-store/v1-metadata,native-store/video,native-store/video-metadata,native-store/pac-metadata,native-store/universal-content,native-store/pages
+  MONGODB_COLLECTIONS: native-store/video,native-store/video-metadata,native-store/pac-metadata,native-store/universal-content,native-store/pages

--- a/helm/mongo-hot-backup/app-configs/mongo-hot-backup_eks_publish_dev_eu.yaml
+++ b/helm/mongo-hot-backup/app-configs/mongo-hot-backup_eks_publish_dev_eu.yaml
@@ -5,4 +5,4 @@ service:
 replicaCount: 1
 
 env:
-  MONGODB_COLLECTIONS: native-store/v1-metadata,native-store/video,native-store/video-metadata,native-store/pac-metadata,native-store/universal-content,native-store/pages
+  MONGODB_COLLECTIONS: native-store/video,native-store/video-metadata,native-store/pac-metadata,native-store/universal-content,native-store/pages


### PR DESCRIPTION
# Description

After the decommissioning of the v1 Annotations Publishing Pipeline(https://financialtimes.atlassian.net/browse/UPPSF-2317), the "v1-metadata" collection in the Native store is not being used anymore.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-2462)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
