### PR TITLE
Added tests and fixed bug with potential unclosed connection

### DIFF
--- a/backupService_test.go
+++ b/backupService_test.go
@@ -143,6 +143,7 @@ func TestBackup_ErrorOnSavingStatus(t *testing.T) {
 
 func TestBackup_ErrorOnlyInUpload(t *testing.T) {
 	start := time.Now()
+	//nolint: staticcheck
 	ctx := context.WithValue(context.Background(), "source", "test")
 	mockedStorageService := new(mockStorageService)
 	mockedStorageService.On("Upload",
@@ -178,6 +179,7 @@ func TestBackup_ErrorOnlyInUpload(t *testing.T) {
 
 func TestBackup_ErrorOnlyInSave(t *testing.T) {
 	start := time.Now()
+	//nolint: staticcheck
 	ctx := context.WithValue(context.Background(), "source", "test")
 	mockedStorageService := new(mockStorageService)
 	mockedStorageService.On("Upload",
@@ -263,6 +265,7 @@ func TestRestore_ErrorOnRestoringCollection(t *testing.T) {
 
 func TestRestore_ErrorDuringRestorationInRestore(t *testing.T) {
 	start := time.Now()
+	//nolint: staticcheck
 	ctx := context.WithValue(context.Background(), "source", "test")
 	mockedStorageService := new(mockStorageService)
 	mockedStorageService.On("Download",
@@ -290,6 +293,7 @@ func TestRestore_ErrorDuringRestorationInRestore(t *testing.T) {
 
 func TestRestore_ErrorDuringRestorationInDownload(t *testing.T) {
 	start := time.Now()
+	//nolint: staticcheck
 	ctx := context.WithValue(context.Background(), "source", "test")
 	mockedStorageService := new(mockStorageService)
 	mockedStorageService.On("Download",

--- a/backupService_test.go
+++ b/backupService_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -140,6 +141,75 @@ func TestBackup_ErrorOnSavingStatus(t *testing.T) {
 	assert.EqualError(t, err, "couldn't save status of backup")
 }
 
+func TestBackup_ErrorOnlyInUpload(t *testing.T) {
+	start := time.Now()
+	ctx := context.WithValue(context.Background(), "source", "test")
+	mockedStorageService := new(mockStorageService)
+	mockedStorageService.On("Upload",
+		mock.MatchedBy(isTestContext),
+		mock.AnythingOfType("string"),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*io.PipeReader")).
+		Return(fmt.Errorf("error uploading collection"))
+	mockedMongoService := new(mockMongoService)
+	mockedMongoService.On("SaveCollection",
+		mock.MatchedBy(isTestContext),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*main.snappyWriteCloser")).
+		After(time.Second * 10).
+		Return(nil)
+	mockedStatusKeeper := new(mockStatusKeeper)
+	mockedStatusKeeper.On("Save",
+		mock.MatchedBy(func(result backupResult) bool {
+			return !result.Success &&
+				result.Collection.collection == "collection1" &&
+				result.Collection.database == "database1"
+		})).Return(nil)
+
+	backupService := newMongoBackupService(mockedMongoService, mockedStorageService, mockedStatusKeeper)
+	err := backupService.Backup(ctx, []dbColl{{"database1", "collection1"}})
+
+	assert.True(t, time.Since(start) < time.Second*10, "all processes should end when error occurs")
+	assert.Error(t, err, "Error was expected during backup.")
+	assert.EqualError(t, err, "dumping failed for database1/collection1: error uploading collection")
+}
+
+func TestBackup_ErrorOnlyInSave(t *testing.T) {
+	start := time.Now()
+	ctx := context.WithValue(context.Background(), "source", "test")
+	mockedStorageService := new(mockStorageService)
+	mockedStorageService.On("Upload",
+		mock.MatchedBy(isTestContext),
+		mock.AnythingOfType("string"),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*io.PipeReader")).
+		Return(nil)
+	mockedMongoService := new(mockMongoService)
+	mockedMongoService.On("SaveCollection",
+		mock.MatchedBy(isTestContext),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*main.snappyWriteCloser")).
+		Return(fmt.Errorf("error saving collection"))
+	mockedStatusKeeper := new(mockStatusKeeper)
+	mockedStatusKeeper.On("Save",
+		mock.MatchedBy(func(result backupResult) bool {
+			return !result.Success &&
+				result.Collection.collection == "collection1" &&
+				result.Collection.database == "database1"
+		})).Return(nil)
+
+	backupService := newMongoBackupService(mockedMongoService, mockedStorageService, mockedStatusKeeper)
+	err := backupService.Backup(ctx, []dbColl{{"database1", "collection1"}})
+
+	assert.True(t, time.Since(start) < time.Second*10, "all processes should end when error occurs")
+	assert.Error(t, err, "Error was expected during backup.")
+	assert.EqualError(t, err, "dumping failed for database1/collection1: error saving collection")
+}
+
 func TestRestore_OK(t *testing.T) {
 	//nolint: staticcheck
 	ctx := context.WithValue(context.Background(), "source", "test")
@@ -189,6 +259,60 @@ func TestRestore_ErrorOnRestoringCollection(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, "error restoring collection")
+}
+
+func TestRestore_ErrorDuringRestorationInRestore(t *testing.T) {
+	start := time.Now()
+	ctx := context.WithValue(context.Background(), "source", "test")
+	mockedStorageService := new(mockStorageService)
+	mockedStorageService.On("Download",
+		mock.MatchedBy(isTestContext),
+		"2017-09-04T12-40-36",
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*io.PipeWriter"),
+	).After(time.Second * 10).Return(nil)
+	mockedMongoService := new(mockMongoService)
+	mockedMongoService.On("RestoreCollection",
+		mock.MatchedBy(isTestContext),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*main.snappyReadCloser"),
+	).Return(fmt.Errorf("error restoring collection"))
+
+	backupService := newMongoBackupService(mockedMongoService, mockedStorageService, nil)
+	err := backupService.Restore(ctx, "2017-09-04T12-40-36", []dbColl{{"database1", "collection1"}})
+
+	assert.True(t, time.Since(start) < time.Second*10, "all processes should end when error occurs")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error restoring collection")
+}
+
+func TestRestore_ErrorDuringRestorationInDownload(t *testing.T) {
+	start := time.Now()
+	ctx := context.WithValue(context.Background(), "source", "test")
+	mockedStorageService := new(mockStorageService)
+	mockedStorageService.On("Download",
+		mock.MatchedBy(isTestContext),
+		"2017-09-04T12-40-36",
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*io.PipeWriter"),
+	).Return(fmt.Errorf("error downloading backup"))
+	mockedMongoService := new(mockMongoService)
+	mockedMongoService.On("RestoreCollection",
+		mock.MatchedBy(isTestContext),
+		"database1",
+		"collection1",
+		mock.AnythingOfType("*main.snappyReadCloser"),
+	).After(time.Second * 10).Return(nil)
+
+	backupService := newMongoBackupService(mockedMongoService, mockedStorageService, nil)
+	err := backupService.Restore(ctx, "2017-09-04T12-40-36", []dbColl{{"database1", "collection1"}})
+
+	assert.True(t, time.Since(start) < time.Second*10, "all processes should end when error occurs")
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error downloading backup")
 }
 
 func TestRestore_ErrorOnDownloadingCollection(t *testing.T) {


### PR DESCRIPTION
# Descript

## What

While trying to restore dev mongo the hot-backup just stopped without logs

## Why

The stop's cause was insufficient storage in the database and a broken write pipe.
The reason the logs didn't show that is that the [errorgroup Wait](https://pkg.go.dev/golang.org/x/sync/errgroup#Group.Wait) function waits for all functions started in Go to finish.

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-4139)

## Solution

The solution in this PR is canceling the context when an error is returned by any of the functions

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
